### PR TITLE
Use the system's libuuid on macOS [skip circle] [skip appveyor]

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -59,6 +59,12 @@ if [ -n "$CYGWIN_PREFIX" ] ; then
     configure_args+=(--disable-unix-transport)
 fi
 
+# Force use of system libuuid on macOS. Due to how the configure script
+# works, LIBUUID_{CFLAGS,LIBS} can't be exactly empty here.
+if [[ $(uname) == Darwin ]] ; then
+    export LIBUUID_CFLAGS=" " LIBUUID_LIBS=" "
+fi
+
 ./configure "${configure_args[@]}"
 make -j$CPU_COUNT
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 4
+  number: 5
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -29,13 +29,13 @@ requirements:
     - {{ compiler('c') }}        # [unix]
     - {{ compiler('m2w64_c') }}  # [win]
   host:
-    - libuuid 1.0.*  # [not win]
+    - libuuid 1.0.*  # [linux]
     - xorg-util-macros
     - xorg-xproto
     - xorg-xtrans
     - xorg-libice 1.0.*
   run:
-    - libuuid 1.0.*  # [not win]
+    - libuuid 1.0.*  # [linux]
     - xorg-libice 1.0.*
 
 test:


### PR DESCRIPTION
The conda-forge version of libuuid can cause compilation errors for packages that want to link to the ApplicationServices bundle, so it's best to avoid it when possible.

(BTW, this CI-skipping annotations never seem to work for me, but at least they convey the intent.)

* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
