### PR TITLE
Repin [skip travis] [skip appveyor]

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,2 +1,7 @@
 c_compiler:
 - toolchain_c
+libuuid:
+- 2.32.1
+pin_run_as_build:
+  libuuid:
+    max_pin: x

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Checklist
 * [ ] Used a fork of the feedstock to propose changes
 * [ ] Bumped the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
-* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
+* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
 * [ ] Ensured the license file is being packaged.
 
 <!--

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 5
+  number: 6
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -29,13 +29,13 @@ requirements:
     - {{ compiler('c') }}        # [unix]
     - {{ compiler('m2w64_c') }}  # [win]
   host:
-    - libuuid 1.0.*  # [linux]
+    - libuuid  # [linux]
     - xorg-util-macros
     - xorg-xproto
     - xorg-xtrans
     - xorg-libice 1.0.*
   run:
-    - libuuid 1.0.*  # [linux]
+    - libuuid  # [linux]
     - xorg-libice 1.0.*
 
 test:


### PR DESCRIPTION
Removing an explicit setting gets the Linux package following conda-forge's pinning of libuuid.

* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.